### PR TITLE
fix: include arch in cache key

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -139,7 +139,7 @@ export async function getToolchainCacheKey() {
 		hasher.update(configVersion);
 	}
 
-	return `${getCacheKeyPrefix()}-${process.platform}-${hasher.digest('hex')}`;
+	return `${getCacheKeyPrefix()}-${process.platform}-${process.arch}-${hasher.digest('hex')}`;
 }
 
 export async function installBin(bin: string) {

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ async function restoreCache() {
 	const cacheKey = await cache.restoreCache(
 		[getPluginsDir(), getToolsDir(), getUidFile()],
 		primaryKey,
-		[`${cachePrefix}-${process.platform}-${process.arch}`, cachePrefix],
+		[`${cachePrefix}-${process.platform}-${process.arch}`],
 	);
 
 	if (cacheKey) {

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ async function restoreCache() {
 	const cacheKey = await cache.restoreCache(
 		[getPluginsDir(), getToolsDir(), getUidFile()],
 		primaryKey,
-		[`${cachePrefix}-${process.platform}`, cachePrefix],
+		[`${cachePrefix}-${process.platform}-${process.arch}`, cachePrefix],
 	);
 
 	if (cacheKey) {


### PR DESCRIPTION
## issue

I recently swapped a job from to an ARM runner and Moon restored `x64` dependencies with predictable results:

```
home/runner/.proto/tools/moon/1.32.9/moon: 1: ELF�E8@�t�@8: not found
/home/runner/.proto/tools/moon/1.32.9/moon: 2: Syntax error: newline unexpected
```

## change

1. Include the arch in the cache key
2. Don't fallback to the generic `cachePrefix` on a miss
   - this was causing a hit to still happen on the old cache entry, so I guess github uses the strings in this fallback array as a _prefix_?
   - I don't actually see why we'd ever want to fallback to anything here as they might be cached for a totally different project? So IMO the other entry I left in the array should be removed too - but I may be missing some context so can approach this differently.

This is a breaking change in so much it will invalidate existing caches, so if preferred it could be made opt-in to begin with (but probably unnecessary?)

### testing

Pointed to my built branch directly and tested w/ an internal repo.
